### PR TITLE
Fix TextInputMask wrong property mask and inputProps

### DIFF
--- a/src/components/TextInput/TextInputMask/index.tsx
+++ b/src/components/TextInput/TextInputMask/index.tsx
@@ -1,8 +1,6 @@
 import { VFC } from 'react';
 import ReactInputMask from 'react-input-mask';
-
 import { TextInputType } from '../../../types';
-
 import { Input } from '../styles';
 
 enum Mask {
@@ -21,7 +19,7 @@ const TextInputMask: VFC<Partial<TextInputType & { maxLength: number }>> = ({
   onBlur,
   onFocus,
   inputProps,
-  maxLength,
+  error,
   variant = 'standard',
   ...rest
 }) => {
@@ -38,9 +36,14 @@ const TextInputMask: VFC<Partial<TextInputType & { maxLength: number }>> = ({
       {(inputMaskProps: any): JSX.Element => (
         <Input
           margin="normal"
-          {...inputMaskProps}
-          inputProps={{ maxLength, ...inputProps }}
+          onChange={onChange}
+          onBlur={onBlur}
+          onFocus={onFocus}
+          error={!!error}
+          inputProps={inputProps}
           variant={variant}
+          {...inputMaskProps}
+          {...rest}
         />
       )}
     </ReactInputMask>

--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -35,15 +35,15 @@ const TextInput: FC<TextInputType> = ({
     if (hasMask) {
       return (
         <TextInputMask
+          {...rest}
           mask={mask}
           maskType={maskType}
           onChange={onChange}
           onBlur={onBlur}
           onFocus={onFocus}
-          maxLength={maxlength ? parseInt(maxlength, 10) : 0}
+          error={!!error}
           variant={variant}
-          inputProps={inputProps}
-          {...rest}
+          inputProps={{ maxLength: maxlength, ...inputProps }}
         />
       );
     }


### PR DESCRIPTION
## O que foi feito? 📝

Propriedade mask, maskType e inputProps estavam sendo passadas de maneira errada para o componente TextInputMask

## Link da estória no Notion 🔗

<!-- cole o link do notion -->

## Está de acordo com os critérios de aceite da estória? ✅

- [ ] Resolve todos os critérios de aceite
- [ ] Resolve partes do critério de aceite
- [ ] Não resolve nenhum critério de aceite

## Screenshots ou GIFs 📸

<!-- dica: use o KAP ou tire um print com cmd + shift + 5 -->

| -----Figma----- | -Implementação- |
| :-------------: | :-------------: |
| <!----aqui----> | <!----aqui----> |

## Tipo de mudança 🏗

- [ ] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [x] Bug fix (mudança non-breaking que conserta um problema)
- [ ] Refactor (mudança non-breaking que melhora o código ou débito técnico)
- [ ] Chore (nenhuma das anteriores, como upgrade de libs)
- [ ] Breaking change 🚨

## Checklist 🧐

- [ ] Testado no Chrome
- [ ] Testado no Safari
